### PR TITLE
Fix .z80 v1 header parsing: border bits, R bit 7, IM mask

### DIFF
--- a/src/spectrum/snapshot.js
+++ b/src/spectrum/snapshot.js
@@ -34,11 +34,13 @@ export class Z80SnapshotLoader {
         regs.set16('PC', header[6] | (header[7] << 8));
         regs.set16('SP', header[8] | (header[9] << 8));
         regs.data.I = header[10];
-        regs.data.R = header[11];
 
-        const flags1 = header[12];
+        // Byte 12 per the .z80 spec: bit 0 = bit 7 of R, bits 1-3 = border,
+        // bit 5 = data compressed. Compatibility rule: 255 means 1.
+        const flags1 = header[12] === 0xff ? 1 : header[12];
+        regs.data.R = (header[11] & 0x7f) | ((flags1 & 0x01) << 7);
         const compressed = (flags1 & 0x20) !== 0;
-        const border = flags1 & 0x07;
+        const border = (flags1 >> 1) & 0x07;
 
         regs.set('E', header[13]);
         regs.set('D', header[14]);
@@ -54,7 +56,7 @@ export class Z80SnapshotLoader {
         regs.set16('IX', header[25] | (header[26] << 8));
         this.cpu.iff1 = header[27] !== 0;
         this.cpu.iff2 = header[28] !== 0;
-        this.cpu.interruptMode = header[29];
+        this.cpu.interruptMode = header[29] & 0x03; // bits 2-7 are other flags
 
         if (this.ula && typeof this.ula.setBorderColor === 'function') {
             this.ula.setBorderColor(border);

--- a/tests/spectrum/snapshot.test.js
+++ b/tests/spectrum/snapshot.test.js
@@ -1,0 +1,79 @@
+import { Z80SnapshotLoader } from '../../src/spectrum/snapshot.js';
+import { SpectrumMemory } from '../../src/spectrum/memory.js';
+import { Registers } from '../../src/core/registers.js';
+
+/**
+ * Build a minimal uncompressed .z80 v1 image: 30-byte header + 48K RAM.
+ */
+function makeSnapshot(headerOverrides = {}) {
+    const header = new Uint8Array(30);
+    for (const [index, value] of Object.entries(headerOverrides)) {
+        header[Number(index)] = value;
+    }
+    const data = new Uint8Array(30 + 49152);
+    data.set(header, 0);
+    return data;
+}
+
+describe('Z80SnapshotLoader', () => {
+    let memory;
+    let cpu;
+    let ula;
+    let loader;
+
+    beforeEach(() => {
+        memory = new SpectrumMemory();
+        cpu = {
+            registers: new Registers(),
+            iff1: false,
+            iff2: false,
+            interruptMode: 0,
+        };
+        ula = { setBorderColor: jest.fn() };
+        loader = new Z80SnapshotLoader(memory, cpu, ula);
+    });
+
+    describe('header byte 12 (flags1)', () => {
+        it('reads the border color from bits 1-3', () => {
+            // border 4 (green) lives at bits 1-3 → 0b0000_1000
+            loader.load(makeSnapshot({ 12: 4 << 1 }));
+            expect(ula.setBorderColor).toHaveBeenCalledWith(4);
+        });
+
+        it('does not misread bit 0 (R bit 7) as part of the border', () => {
+            // R7 set + border 0 → border must be 0, not 1
+            loader.load(makeSnapshot({ 12: 0x01 }));
+            expect(ula.setBorderColor).toHaveBeenCalledWith(0);
+        });
+
+        it('restores bit 7 of R from bit 0 of flags1', () => {
+            loader.load(makeSnapshot({ 11: 0x12, 12: 0x01 }));
+            expect(cpu.registers.data.R).toBe(0x92);
+        });
+
+        it('treats flags1 = 255 as 1 (spec compatibility rule)', () => {
+            loader.load(makeSnapshot({ 12: 0xff }));
+            expect(ula.setBorderColor).toHaveBeenCalledWith(0); // not 7
+            expect(cpu.registers.data.R & 0x80).toBe(0x80); // R7 from bit 0
+        });
+    });
+
+    describe('header byte 29 (interrupt mode)', () => {
+        it('masks the interrupt mode to bits 0-1', () => {
+            // 0x41 = IM 1 plus an unrelated high flag bit
+            loader.load(makeSnapshot({ 29: 0x41 }));
+            expect(cpu.interruptMode).toBe(1);
+        });
+    });
+
+    describe('uncompressed RAM', () => {
+        it('writes the 48K block to 0x4000-0xFFFF', () => {
+            const data = makeSnapshot({});
+            data[30] = 0xaa; // first RAM byte → 0x4000
+            data[30 + 49151] = 0x55; // last RAM byte → 0xFFFF
+            loader.load(data);
+            expect(memory.read(0x4000)).toBe(0xaa);
+            expect(memory.read(0xffff)).toBe(0x55);
+        });
+    });
+});


### PR DESCRIPTION
## What

Three spec-conformance fixes in `Z80SnapshotLoader`, all in header parsing:

- **Border color**: byte 12 stores the border in **bits 1-3**; the loader read `flags1 & 0x07`, which includes bit 0 (R's bit 7) and drops bit 3. Now `(flags1 >> 1) & 0x07`.
- **R bit 7**: bit 0 of byte 12 is the missing high bit of R; it was discarded. Now `R = (byte11 & 0x7F) | ((flags1 & 1) << 7)`.
- **Interrupt mode**: byte 29 carries IM in **bits 0-1** only; the joystick/flag bits above were leaking into `cpu.interruptMode`. Now masked with `& 0x03`.
- Also applies the spec's compatibility rule: byte 12 = 255 must be treated as 1.

## Why

[Spectral](https://github.com/Alvaromah/spectral) exports `.z80` v1 snapshots (e.g. for the browser gallery) that this loader reads back — any snapshot with a non-trivial border or IM flags loads subtly wrong.

## Tests

New `tests/spectrum/snapshot.test.js` (the loader had no coverage): 6 cases for flags1 decoding, IM masking and uncompressed RAM placement. Full suite: 309/309 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)