### PR TITLE
Z80.getState()/setState(): include the shadow register set

### DIFF
--- a/src/core/cpu.js
+++ b/src/core/cpu.js
@@ -294,7 +294,17 @@ class Z80 {
             e: this.registers.get('E'),
             h: this.registers.get('H'),
             l: this.registers.get('L'),
-            
+
+            // Shadow register set (EX AF,AF' / EXX)
+            a_: this.registers.get('A_'),
+            f_: this.registers.get('F_'),
+            b_: this.registers.get('B_'),
+            c_: this.registers.get('C_'),
+            d_: this.registers.get('D_'),
+            e_: this.registers.get('E_'),
+            h_: this.registers.get('H_'),
+            l_: this.registers.get('L_'),
+
             // 16-bit index registers
             ix: this.registers.get16('IX'),
             iy: this.registers.get16('IY'),
@@ -326,6 +336,14 @@ class Z80 {
      * @param {number} [state.e] - E register
      * @param {number} [state.h] - H register
      * @param {number} [state.l] - L register
+     * @param {number} [state.a_] - Shadow accumulator (A')
+     * @param {number} [state.f_] - Shadow flags (F')
+     * @param {number} [state.b_] - Shadow B register (B')
+     * @param {number} [state.c_] - Shadow C register (C')
+     * @param {number} [state.d_] - Shadow D register (D')
+     * @param {number} [state.e_] - Shadow E register (E')
+     * @param {number} [state.h_] - Shadow H register (H')
+     * @param {number} [state.l_] - Shadow L register (L')
      * @param {number} [state.ix] - IX index register
      * @param {number} [state.iy] - IY index register
      * @param {number} [state.i] - Interrupt vector register
@@ -358,7 +376,17 @@ class Z80 {
         if (state.e !== undefined) this.registers.set('E', state.e);
         if (state.h !== undefined) this.registers.set('H', state.h);
         if (state.l !== undefined) this.registers.set('L', state.l);
-        
+
+        // Shadow register set
+        if (state.a_ !== undefined) this.registers.set('A_', state.a_);
+        if (state.f_ !== undefined) this.registers.set('F_', state.f_);
+        if (state.b_ !== undefined) this.registers.set('B_', state.b_);
+        if (state.c_ !== undefined) this.registers.set('C_', state.c_);
+        if (state.d_ !== undefined) this.registers.set('D_', state.d_);
+        if (state.e_ !== undefined) this.registers.set('E_', state.e_);
+        if (state.h_ !== undefined) this.registers.set('H_', state.h_);
+        if (state.l_ !== undefined) this.registers.set('L_', state.l_);
+
         // 16-bit index registers
         if (state.ix !== undefined) this.registers.set16('IX', state.ix);
         if (state.iy !== undefined) this.registers.set16('IY', state.iy);

--- a/tests/core/cpu.test.js
+++ b/tests/core/cpu.test.js
@@ -199,6 +199,37 @@ describe('Z80 CPU', () => {
       expect(state.halted).toBe(true);
       expect(state.cycles).toBe(1000);
     });
+
+    it('should include the shadow register set in getState', () => {
+      cpu.registers.set('A', 0x11);
+      cpu.registers.set('F', 0x22);
+      cpu.registers.setBC(0x3344);
+      cpu.registers.exchangeAF(); // park values in AF'
+      cpu.registers.exchangeAll(); // park values in BC'/DE'/HL'
+
+      const state = cpu.getState();
+      expect(state.a_).toBe(0x11);
+      expect(state.f_).toBe(0x22);
+      expect(state.b_).toBe(0x33);
+      expect(state.c_).toBe(0x44);
+    });
+
+    it('should round-trip shadow registers through setState', () => {
+      cpu.setState({
+        a_: 0xaa, f_: 0xbb,
+        b_: 0x01, c_: 0x02,
+        d_: 0x03, e_: 0x04,
+        h_: 0x05, l_: 0x06,
+      });
+
+      cpu.registers.exchangeAF();
+      cpu.registers.exchangeAll(); // swap shadows into the main set
+      expect(cpu.registers.get('A')).toBe(0xaa);
+      expect(cpu.registers.get('F')).toBe(0xbb);
+      expect(cpu.getBC()).toBe(0x0102);
+      expect(cpu.getDE()).toBe(0x0304);
+      expect(cpu.getHL()).toBe(0x0506);
+    });
   });
 
   describe('legacy register methods', () => {


### PR DESCRIPTION
## What

`getState()` now returns the shadow set as flat `a_, f_, b_, c_, d_, e_, h_, l_` keys (matching the internal `A_..L_` storage names), and `setState()` restores them with the same per-key opt-in semantics as every other field. JSDoc updated.

## Why

A save/restore round-trip through `getState()`/`setState()` silently zeroed AF'/BC'/DE'/HL'. Any program that uses `EX AF,AF'` or `EXX` — which is most interrupt handlers and a lot of performance-sensitive Z80 code — resumed with corrupted shadow registers.

[Spectral](https://github.com/Alvaromah/spectral) hit this implementing `.zxstate` session files (its CLI is one-shot: every command saves and restores the full machine state, so the state surface has to be complete). It currently works around it by reaching into `registers.data` directly.

## Tests

Two new cases in `tests/core/cpu.test.js`: getState observes values parked via `exchangeAF()`/`exchangeAll()`, and a setState round-trip swaps shadows back into the main set. Full suite: 305/305 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)