### PR TITLE
Node-safe guards: construct and run the emulator headless

### DIFF
--- a/src/spectrum/display.js
+++ b/src/spectrum/display.js
@@ -427,6 +427,12 @@ export class SpectrumDisplay {
      * ctx.putImageData(imageData, 0, 0);
      */
     getImageData() {
+        if (typeof ImageData === 'undefined') {
+            throw new Error(
+                'ImageData is not available in this environment (Node). ' +
+                'Read the raw RGBA pixels from display.displayBuffer instead.'
+            );
+        }
         // Create ImageData object with the display buffer
         return new ImageData(
             new Uint8ClampedArray(this.displayBuffer),

--- a/src/spectrum/spectrum.js
+++ b/src/spectrum/spectrum.js
@@ -155,6 +155,12 @@ export class ZXSpectrum {
     _resolveCanvas(canvasOrSelector) {
         if (typeof canvasOrSelector === 'string') {
             // It's a selector
+            if (typeof document === 'undefined') {
+                throw new Error(
+                    'Canvas selectors need a DOM. In Node, pass a canvas-like object ' +
+                    '(e.g. from the "canvas" package) instead of a selector string.'
+                );
+            }
             const element = document.querySelector(canvasOrSelector);
             if (!element) {
                 throw new Error(`Canvas element not found: ${canvasOrSelector}`);
@@ -166,7 +172,10 @@ export class ZXSpectrum {
                 return canvas;
             }
             return element;
-        } else if (canvasOrSelector instanceof HTMLCanvasElement) {
+        } else if (
+            typeof HTMLCanvasElement !== 'undefined' &&
+            canvasOrSelector instanceof HTMLCanvasElement
+        ) {
             return canvasOrSelector;
         } else if (canvasOrSelector && canvasOrSelector.tagName === 'CANVAS') {
             return canvasOrSelector;
@@ -214,10 +223,12 @@ export class ZXSpectrum {
         // Store bound functions for removal
         this._keyDownHandler = (e) => this._handleKeyDown(e);
         this._keyUpHandler = (e) => this._handleKeyUp(e);
-        
-        // Add event listeners
-        document.addEventListener('keydown', this._keyDownHandler);
-        document.addEventListener('keyup', this._keyUpHandler);
+
+        // Add event listeners (headless callers drive keyDown()/keyUp() directly)
+        if (typeof document !== 'undefined') {
+            document.addEventListener('keydown', this._keyDownHandler);
+            document.addEventListener('keyup', this._keyUpHandler);
+        }
     }
     
     /**
@@ -254,6 +265,9 @@ export class ZXSpectrum {
      * @returns {boolean} True if touch device
      */
     _isTouchDevice() {
+        if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+            return false; // headless
+        }
         return 'ontouchstart' in window || 
                navigator.maxTouchPoints > 0 ||
                navigator.msMaxTouchPoints > 0;

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -24,8 +24,9 @@ global.AudioContext = jest.fn().mockImplementation(() => ({
 // Mock AudioWorklet
 global.AudioWorkletNode = jest.fn();
 
-// Mock Canvas API
-HTMLCanvasElement.prototype.getContext = jest.fn().mockImplementation((type) => {
+// Mock Canvas API (only under jsdom — node-environment test files have no DOM)
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = jest.fn().mockImplementation((type) => {
   if (type === '2d') {
     return {
       createImageData: jest.fn(() => ({
@@ -36,10 +37,11 @@ HTMLCanvasElement.prototype.getContext = jest.fn().mockImplementation((type) => 
       putImageData: jest.fn(),
       fillRect: jest.fn(),
       fillStyle: '',
-    };
-  }
-  return null;
-});
+      };
+    }
+    return null;
+  });
+}
 
 // Mock requestAnimationFrame
 global.requestAnimationFrame = jest.fn((cb) => {

--- a/tests/spectrum/node-headless.test.js
+++ b/tests/spectrum/node-headless.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ *
+ * Headless (Node, no DOM) smoke tests: the emulator must be constructible
+ * and runnable without HTMLCanvasElement / document / ImageData.
+ */
+import { ZXSpectrum } from '../../src/spectrum/spectrum.js';
+import { SpectrumDisplay } from '../../src/spectrum/display.js';
+
+function stubCanvas() {
+    return {
+        tagName: 'CANVAS',
+        width: 0,
+        height: 0,
+        style: {},
+        getContext: () => ({
+            putImageData: () => {},
+            fillRect: () => {},
+        }),
+        addEventListener: () => {},
+    };
+}
+
+describe('headless Node environment', () => {
+    it('has no DOM globals (sanity)', () => {
+        expect(typeof document).toBe('undefined');
+        expect(typeof HTMLCanvasElement).toBe('undefined');
+        expect(typeof ImageData).toBe('undefined');
+    });
+
+    it('constructs with a canvas-like object without touching browser globals', () => {
+        const spectrum = new ZXSpectrum(stubCanvas(), { sound: false, rom: null });
+        expect(spectrum.cpu).toBeDefined();
+        expect(spectrum.memory).toBeDefined();
+    });
+
+    it('runs frames headless once a ROM is loaded', () => {
+        const spectrum = new ZXSpectrum(stubCanvas(), { sound: false, rom: null });
+        spectrum.loadROM(new Uint8Array(16384)); // zero-filled ROM: NOPs
+        const before = spectrum.cpu.cycles;
+        spectrum.runFrame();
+        expect(spectrum.cpu.cycles).toBeGreaterThan(before);
+    });
+
+    it('rejects selector strings with a clear error instead of a ReferenceError', () => {
+        expect(() => new ZXSpectrum('#screen', { sound: false, rom: null }))
+            .toThrow(/Canvas selectors need a DOM/);
+    });
+
+    it('display.getImageData() explains itself instead of throwing a ReferenceError', () => {
+        const display = new SpectrumDisplay();
+        expect(() => display.getImageData()).toThrow(/displayBuffer/);
+    });
+});


### PR DESCRIPTION
## What

Typeof-guards for the browser globals the emulator touches during construction, so `ZXSpectrum` works in Node with a canvas-like object:

- `_resolveCanvas`: the `instanceof HTMLCanvasElement` check threw a `ReferenceError` in Node **before** reaching the existing duck-typed `tagName === 'CANVAS'` branch — guard it. Selector strings now throw a clear "needs a DOM" error instead.
- `_setupKeyboard`: `document.addEventListener` guarded (headless callers drive `keyDown()`/`keyUp()` directly).
- `_isTouchDevice`: returns false when `window`/`navigator` are absent.
- `display.getImageData()`: explains the alternative (`display.displayBuffer`) instead of `ReferenceError: ImageData is not defined`.
- `tests/setup.js`: the canvas prototype mock is skipped for `@jest-environment node` suites.

## Why

[Spectral](https://github.com/Alvaromah/spectral) runs this emulator headless in Node (~6,600 fps) as the feedback loop for AI agents writing Spectrum games. It currently composes the internal classes directly partly because the top-level class can't be constructed without a DOM.

## Tests

New `tests/spectrum/node-headless.test.js` (runs under `@jest-environment node`): asserts the DOM globals are truly absent, constructs with a stub canvas, runs a frame on a zero-filled ROM, and checks both clear-error paths. Full suite: 308/308 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)