### PR TITLE
Add src/index.js entry point and package.json exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
   "main": "dist/zxgeneration.umd.min.js",
   "module": "dist/zxgeneration.esm.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "default": "./dist/zxgeneration.umd.min.js"
+    },
+    "./src/*": "./src/*",
+    "./dist/*": "./dist/*",
+    "./rom/*": "./rom/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "start": "npx serve . -p 8080",
     "serve": "npx serve . -p 8080",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ const banner = `/**
 export default [
   // ES Module build
   {
-    input: 'src/spectrum/spectrum.js',
+    input: 'src/index.js',
     output: {
       file: 'dist/zxgeneration.esm.js',
       format: 'es',
@@ -28,7 +28,7 @@ export default [
   },
   // UMD build (for browsers)
   {
-    input: 'src/spectrum/spectrum.js',
+    input: 'src/index.js',
     output: {
       file: 'dist/zxgeneration.umd.js',
       format: 'umd',
@@ -46,7 +46,7 @@ export default [
   },
   // Minified UMD build
   {
-    input: 'src/spectrum/spectrum.js',
+    input: 'src/index.js',
     output: {
       file: 'dist/zxgeneration.umd.min.js',
       format: 'umd',

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,19 @@
+/**
+ * ZXGeneration public entry point.
+ *
+ * Most users want only ZXSpectrum; the rest of the surface is exported for
+ * headless / embedded use (custom front-ends, testing rigs, tooling that
+ * composes the machine from parts).
+ */
+export { ZXSpectrum } from './spectrum/spectrum.js';
+
+// The machine, by parts
+export { Z80 } from './core/cpu.js';
+export { Registers } from './core/registers.js';
+export { Flags } from './core/flags.js';
+export { SpectrumMemory } from './spectrum/memory.js';
+export { SpectrumULA, SPECTRUM_KEYS, PC_KEY_MAP } from './spectrum/ula.js';
+export { SpectrumDisplay } from './spectrum/display.js';
+export { SpectrumSound } from './spectrum/sound.js';
+export { Z80SnapshotLoader } from './spectrum/snapshot.js';
+export { Tape } from './spectrum/tape.js';

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,0 +1,27 @@
+/**
+ * The package entry point must expose the public surface — consumers
+ * should never need to know internal file paths.
+ */
+import * as zx from '../src/index.js';
+
+describe('package entry point (src/index.js)', () => {
+    it.each([
+        'ZXSpectrum',
+        'Z80',
+        'Registers',
+        'Flags',
+        'SpectrumMemory',
+        'SpectrumULA',
+        'SpectrumDisplay',
+        'SpectrumSound',
+        'Z80SnapshotLoader',
+        'Tape',
+    ])('exports %s', (name) => {
+        expect(typeof zx[name]).toBe('function');
+    });
+
+    it('exports the keyboard maps', () => {
+        expect(zx.SPECTRUM_KEYS).toBeDefined();
+        expect(zx.PC_KEY_MAP).toBeDefined();
+    });
+});


### PR DESCRIPTION
## What

- **`src/index.js`**: public entry re-exporting `ZXSpectrum` plus the machine by parts (`Z80`, `Registers`, `Flags`, `SpectrumMemory`, `SpectrumULA` + key maps, `SpectrumDisplay`, `SpectrumSound`, `Z80SnapshotLoader`, `Tape`).
- **`package.json` `exports` map**: `.` → `src/index.js` for `import`, UMD bundle as fallback; `./src/*`, `./dist/*`, `./rom/*` and `./package.json` stay importable. The subpath entries matter: adding an `exports` field without them would have **broken** every existing deep-import consumer, since `exports` closes the package surface.
- Rollup bundles now build from the new entry, so the dist builds gain the same named exports.

## Why

Headless/embedding consumers need the internals (`Z80`, `SpectrumMemory`, …) but previously had to hardcode internal file paths. [Spectral](https://github.com/Alvaromah/spectral) pins this package EXACTLY to 1.0.1 because its deep imports have no contract — a public entry point is that contract.

## Verification

- New `tests/index.test.js` asserts the exported surface; full suite 314/314 green.
- `npm pack` + install into a scratch project: `import { Z80 } from 'zx-generation'` and `import { Z80 } from 'zx-generation/src/core/cpu.js'` both resolve, to the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)